### PR TITLE
Fix collision detection skipping all platforms

### DIFF
--- a/Character.java
+++ b/Character.java
@@ -16,7 +16,6 @@ public class Character {
     Color color = Color.pink;
 
 
-    KillingPlatformDecorator killingPlatform;
 
     public Character(int x, int y, int width, int height) {
         this.x = x;
@@ -52,7 +51,7 @@ public class Character {
 
         for (Platform platform : platforms) {
             if (checkCollision(potentialX, potentialY, platform)) {
-                if (!platforms.contains(killingPlatform)) {
+                if (!(platform instanceof KillingPlatformDecorator)) {
                     collided = true;
                     yVelocity = 0;
                     if (potentialY > y) { // Postać spada na platformę


### PR DESCRIPTION
## Summary
- remove unused `killingPlatform` field from `Character`
- ensure update handles collision with any platform except killing platforms using `instanceof`

## Testing
- `javac *.java`
- `java GameWindow` *(fails: HeadlessException)*

------
https://chatgpt.com/codex/tasks/task_e_6875096e02588331948b2a0f3897230a